### PR TITLE
Add Flask web UI and API to run pipeline by race_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ python -m course.course_score --race_id <race_id> --course 東京 --surface 芝 
 
 ---
 
+
+## 🖥️ race_id入力で結果表示するUI
+
+`web/app.py` でローカルWeb UIを起動できます。
+
+```bash
+python web/app.py
+```
+
+詳細な環境構築手順（フロントエンド/バックエンド分離説明を含む）は
+`docs/local_frontend_backend_setup.md` を参照してください。
+
+---
+
 ## 📁 ディレクトリ
 
 ```text
@@ -100,6 +114,7 @@ preprocess/   # 距離/タイム/通過順などの変換ユーティリティ
 scoring/      # 過去5走から speed/closing/lead を算出
 course/       # コース重みを適用して最終スコア化
 predict/      # 補助スクリプト
+web/          # race_id入力UI（Flask + HTML/CSS/JS）
 config/       # コース重み設定
 assets/       # 中間CSV・出力CSV
 reports/      # 最終テキストレポート

--- a/docs/local_frontend_backend_setup.md
+++ b/docs/local_frontend_backend_setup.md
@@ -1,0 +1,66 @@
+# race_id入力UI（フロントエンド + バックエンド）ローカル実行手順
+
+このドキュメントは、`web/app.py` を使って **race_id を入力するだけで結果をUI表示** するための最小セットアップ手順です。
+
+---
+
+## 1. 必要環境（共通）
+
+- Python 3.10+
+- Google Chrome（crawler 実行時に使用）
+
+> 既に `assets/race_<race_id>_..._course_scores.csv` が存在する race_id を使う場合、Chrome/Selenium を使わずに表示できるケースがあります。
+
+---
+
+## 2. 初回セットアップ（共通）
+
+```bash
+cd /workspace/keiba-scoring-model
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install flask pandas selenium webdriver-manager
+```
+
+---
+
+## 3. バックエンド実行（API + テンプレート配信）
+
+```bash
+cd /workspace/keiba-scoring-model
+source .venv/bin/activate
+python web/app.py
+```
+
+- 起動URL: `http://localhost:8000`
+- API: `POST /api/predict`
+  - body: `{ "race_id": "202405020811" }`
+
+### API を CLI で叩く例
+
+```bash
+curl -X POST http://localhost:8000/api/predict \
+  -H 'Content-Type: application/json' \
+  -d '{"race_id":"202405020811"}'
+```
+
+---
+
+## 4. フロントエンド実行
+
+このUIは Flask が配信する静的HTML/JSです。追加ビルドは不要です。
+
+1. ブラウザで `http://localhost:8000` を開く
+2. `race_id` を入力
+3. 「取得する」をクリック
+4. モデル順位（馬名・スコア）を表で確認
+
+---
+
+## 5. 失敗時の確認ポイント
+
+- `race_id` は数字のみ入力
+- 新しい race_id で crawler が動く場合は、実行に時間がかかることがあります
+- Chrome が未インストールだと crawler 実行時に失敗します
+- ログは画面下の「実行ログ」で確認できます

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import pandas as pd
+
+from web.app import _build_result
+
+
+def test_build_result_ranking(tmp_path: Path):
+    csv_path = tmp_path / "race_202401010101_東京_芝1600m_course_scores.csv"
+    df = pd.DataFrame(
+        {
+            "馬名": ["A", "B", "C"],
+            "東京適性スコア": [61.2, 58.0, 61.2],
+        }
+    )
+    df.to_csv(csv_path, index=False)
+
+    result = _build_result(csv_path)
+
+    assert result["race"]["race_id"] == "202401010101"
+    assert result["race"]["course"] == "東京"
+    assert result["ranking"][0]["rank"] == 1
+    assert result["ranking"][1]["rank"] == 1
+    assert result["ranking"][2]["rank"] == 2

--- a/web/app.py
+++ b/web/app.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+from flask import Flask, jsonify, render_template, request
+
+from preprocess.race_filename import parse_race_meta_from_filename
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+ASSETS_DIR = PROJECT_ROOT / "assets"
+
+app = Flask(
+    __name__,
+    template_folder=str(Path(__file__).resolve().parent / "templates"),
+    static_folder=str(Path(__file__).resolve().parent / "static"),
+)
+
+
+def _find_course_score_csv(race_id: str) -> Path:
+    candidates = list(ASSETS_DIR.glob(f"race_{race_id}_*_course_scores.csv"))
+    if not candidates:
+        raise FileNotFoundError("course_scores.csv が見つかりません")
+    candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return candidates[0]
+
+
+def _run_pipeline(race_id: str) -> tuple[int, str]:
+    cmd = [
+        sys.executable,
+        str(PROJECT_ROOT / "run_pipeline_with_report.py"),
+        "--race_id",
+        race_id,
+    ]
+    proc = subprocess.run(
+        cmd,
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    log = (proc.stdout or "") + ("\n" + proc.stderr if proc.stderr else "")
+    return proc.returncode, log.strip()
+
+
+def _build_result(csv_path: Path) -> dict:
+    meta = parse_race_meta_from_filename(csv_path.name)
+    df = pd.read_csv(csv_path)
+
+    score_cols = [c for c in df.columns if c.endswith("適性スコア")]
+    if not score_cols:
+        raise ValueError("適性スコア列が見つかりません")
+
+    score_col = score_cols[0]
+    result_df = df[["馬名", score_col]].dropna().copy()
+    result_df["モデル順位"] = result_df[score_col].rank(
+        ascending=False, method="dense"
+    ).astype(int)
+    result_df = result_df.sort_values(["モデル順位", score_col], ascending=[True, False])
+
+    ranking = [
+        {
+            "rank": int(row["モデル順位"]),
+            "horse": row["馬名"],
+            "score": round(float(row[score_col]), 3),
+        }
+        for _, row in result_df.iterrows()
+    ]
+
+    return {
+        "race": {
+            "race_id": meta["race_id"],
+            "course": meta["course"],
+            "surface": meta["surface"],
+            "distance": meta["distance"],
+        },
+        "score_column": score_col,
+        "ranking": ranking,
+    }
+
+
+@app.get("/")
+def index():
+    return render_template("index.html")
+
+
+@app.post("/api/predict")
+def predict():
+    payload = request.get_json(silent=True) or {}
+    race_id = str(payload.get("race_id", "")).strip()
+
+    if not race_id.isdigit():
+        return jsonify({"error": "race_id は数字のみで入力してください"}), 400
+
+    code, log = _run_pipeline(race_id)
+    if code != 0:
+        return (
+            jsonify(
+                {
+                    "error": "パイプライン実行に失敗しました",
+                    "log": log,
+                }
+            ),
+            500,
+        )
+
+    try:
+        csv_path = _find_course_score_csv(race_id)
+        result = _build_result(csv_path)
+    except Exception as exc:
+        return jsonify({"error": str(exc), "log": log}), 500
+
+    result["log"] = log
+    return jsonify(result)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000, debug=True)

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1,0 +1,63 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background: #f4f6f8;
+  color: #222;
+}
+
+.container {
+  max-width: 840px;
+  margin: 40px auto;
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
+}
+
+form {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+input {
+  padding: 8px 10px;
+  min-width: 260px;
+}
+
+button {
+  padding: 8px 14px;
+  border: none;
+  border-radius: 6px;
+  background: #0d6efd;
+  color: #fff;
+  cursor: pointer;
+}
+
+.status {
+  margin: 12px 0;
+  font-weight: 600;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border-bottom: 1px solid #ddd;
+  padding: 8px;
+  text-align: left;
+}
+
+.hidden {
+  display: none;
+}
+
+pre {
+  white-space: pre-wrap;
+  background: #f7f7f7;
+  padding: 10px;
+  border-radius: 6px;
+}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>競馬スコア表示UI</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>競馬スコア表示UI</h1>
+      <p>race_id を入力すると、スコア算出パイプラインを実行して順位を表示します。</p>
+
+      <form id="predict-form">
+        <label for="race_id">race_id</label>
+        <input id="race_id" name="race_id" type="text" inputmode="numeric" required placeholder="例: 202405020811" />
+        <button type="submit">取得する</button>
+      </form>
+
+      <section id="status" class="status"></section>
+
+      <section id="result" class="result hidden">
+        <h2 id="race-title"></h2>
+        <table>
+          <thead>
+            <tr>
+              <th>順位</th>
+              <th>馬名</th>
+              <th>スコア</th>
+            </tr>
+          </thead>
+          <tbody id="ranking-body"></tbody>
+        </table>
+      </section>
+
+      <details>
+        <summary>実行ログ</summary>
+        <pre id="log-output"></pre>
+      </details>
+    </main>
+
+    <script>
+      const form = document.getElementById("predict-form");
+      const status = document.getElementById("status");
+      const result = document.getElementById("result");
+      const raceTitle = document.getElementById("race-title");
+      const rankingBody = document.getElementById("ranking-body");
+      const logOutput = document.getElementById("log-output");
+
+      form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+
+        const raceId = document.getElementById("race_id").value.trim();
+        status.textContent = "計算中です...";
+        result.classList.add("hidden");
+        rankingBody.innerHTML = "";
+        logOutput.textContent = "";
+
+        try {
+          const response = await fetch("/api/predict", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ race_id: raceId }),
+          });
+
+          const data = await response.json();
+          logOutput.textContent = data.log || "";
+
+          if (!response.ok) {
+            status.textContent = `エラー: ${data.error || "不明なエラー"}`;
+            return;
+          }
+
+          const race = data.race;
+          raceTitle.textContent = `race_id: ${race.race_id} / ${race.course} ${race.surface}${race.distance}m`;
+
+          data.ranking.forEach((item) => {
+            const tr = document.createElement("tr");
+            tr.innerHTML = `<td>${item.rank}</td><td>${item.horse}</td><td>${item.score}</td>`;
+            rankingBody.appendChild(tr);
+          });
+
+          result.classList.remove("hidden");
+          status.textContent = `取得完了: ${data.ranking.length}頭`;
+        } catch (error) {
+          status.textContent = `通信エラー: ${error}`;
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a minimal local UI so a user can input a `race_id` and see the pipeline results without heavy frontend build tools. 
- Reuse the existing pipeline logic so the UI only orchestrates execution and displays ranked results.

### Description
- Added a lightweight Flask backend `web/app.py` that exposes `GET /` to serve the UI and `POST /api/predict` to run the pipeline for a given `race_id`, collect logs, and return ranked results as JSON. 
- Added a minimal frontend in `web/templates/index.html` and `web/static/style.css` that accepts `race_id`, calls the API, and displays a ranking table and execution log. 
- Added local setup and run instructions in `docs/local_frontend_backend_setup.md` and a short README entry to document `python web/app.py` startup. 
- Added a unit test `tests/test_web_app.py` for the ranking construction logic used by the UI.

### Testing
- `PYTHONPATH=. pytest -q tests/test_race_filename.py tests/test_simple_rank.py` passed (all tests succeeded). 
- `python -m compileall web run_pipeline_with_report.py` succeeded (both files compiled). 
- `pytest -q` failed during collection in this environment due to missing `pandas` (package installation/network constraint), and `python web/app.py` likewise failed with `ModuleNotFoundError: pandas`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f618a282483258f2967baaa3fac4b)